### PR TITLE
[codex] Add cross-platform Terraform pre-commit guidance

### DIFF
--- a/.github/workflows/Generate-StyleGuideArtifacts.ps1
+++ b/.github/workflows/Generate-StyleGuideArtifacts.ps1
@@ -81,15 +81,16 @@ function New-StyleGuideTerraformInstructionsVersion {
     try {
         $strContent = Get-Content -Path $SourcePath -Raw -Encoding UTF8
         
-        # Define the YAML frontmatter with blank line after closing delimiter
-        $strFrontmatter = @"
----
-applyTo: "**/*.tf,**/*.tfvars,**/*.tftest.hcl,**/*.tf.json,**/*.tftpl,**/*.tfbackend"
-description: "Terraform coding standards: secure, modular, and well-documented infrastructure as code."
----
-
-
-"@
+        # Define the YAML frontmatter with LF newlines so regenerated files stay
+        # stable across Windows and POSIX runners.
+        $strFrontmatter = @(
+            '---'
+            'applyTo: "**/*.tf,**/*.tfvars,**/*.tftest.hcl,**/*.tf.json,**/*.tftpl,**/*.tfbackend"'
+            'description: "Terraform coding standards: secure, modular, and well-documented infrastructure as code."'
+            '---'
+            ''
+            ''
+        ) -join "`n"
         
         # Prepend frontmatter to content
         $strFullContent = $strFrontmatter + $strContent

--- a/.github/workflows/package-lock.json
+++ b/.github/workflows/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "psstyleguide",
+  "name": "terraformstyleguide",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "psstyleguide",
+      "name": "terraformstyleguide",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -240,7 +240,7 @@ terraform fmt -check -recursive
 terraform fmt -recursive
 ```
 
-**Pre-commit integration (for repositories with supported POSIX-compatible shell hook execution):**
+**Pre-commit integration (for repositories that support POSIX-compatible shell hook execution):**
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3437,7 +3437,7 @@ Security scanning tools **SHOULD** be integrated into the development workflow.
 #### Pre-commit Integration Example (POSIX-compatible Shell)
 
 This example assumes the repository supports POSIX-compatible shell hook execution. Use cross-platform repo-local
-wrappers when native Windows / PowerShell contributors must run hooks without Git Bash or WSL assumptions.
+wrappers when native Windows/PowerShell contributors must run hooks without Git Bash or WSL assumptions.
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3989,8 +3989,8 @@ Pre-commit hooks for Terraform **SHOULD** include:
 
 ### Cross-platform Hook Execution
 
-Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows /
-PowerShell contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
+Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows/PowerShell
+contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
 WSL, macOS, or Linux for local validation.
 
 For cross-platform Terraform pre-commit validation, prefer repo-local hooks or wrappers in a runtime already required by

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -2,13 +2,13 @@
 
 # Terraform Writing Style
 
-**Version:** 2.3.20260509.0
+**Version:** 2.4.20260511.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-05-09
+- **Last Updated:** 2026-05-11
 - **Scope:** Terraform coding standards for all `.tf`, `.tfvars`, `.tftest.hcl`, `.tf.json`, `.tftpl`, and `.tfbackend` files in this repository — style, formatting, naming, file organization, variable and output design, resource configuration, module design, state management, cross-stack data sharing, provider management, security, testing, and documentation.
 
 ## Keywords
@@ -76,6 +76,7 @@ This checklist provides a quick reference for both human developers and LLMs (li
 ### Continuous Validation (Quick Reference)
 
 - **[All]** `check` blocks **MAY** be used for continuous validation
+- **[All]** Terraform pre-commit hooks **SHOULD** avoid shell assumptions for native Windows/PowerShell contributors
 
 ### Resource Configuration (Quick Reference)
 
@@ -239,7 +240,7 @@ terraform fmt -check -recursive
 terraform fmt -recursive
 ```
 
-**Pre-commit integration:**
+**Pre-commit integration (for repositories with supported POSIX-compatible shell hook execution):**
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3433,7 +3434,10 @@ Security scanning tools **SHOULD** be integrated into the development workflow.
 
 > **Note:** `tfsec` has been absorbed into Aqua Security's `trivy` and is now in maintenance mode. New projects **SHOULD** use `trivy` for Terraform security scanning. Existing workflows using `tfsec` will continue to work but **SHOULD** plan migration to `trivy`.
 
-#### Pre-commit Integration Example
+#### Pre-commit Integration Example (POSIX-compatible Shell)
+
+This example assumes the repository supports POSIX-compatible shell hook execution. Use cross-platform repo-local
+wrappers when native Windows / PowerShell contributors must run hooks without Git Bash or WSL assumptions.
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3983,6 +3987,22 @@ Pre-commit hooks for Terraform **SHOULD** include:
 3. `tflint` — Linting
 4. Security scanning (optional but recommended)
 
+### Cross-platform Hook Execution
+
+Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows /
+PowerShell contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
+WSL, macOS, or Linux for local validation.
+
+For cross-platform Terraform pre-commit validation, prefer repo-local hooks or wrappers in a runtime already required by
+the repository's validation stack, such as Python when pre-commit is already in use. Wrappers **SHOULD** invoke Terraform
+and related tools with shell execution disabled, **SHOULD** resolve executables through `PATH`, and **SHOULD** fail with
+clear installation guidance when required tools such as `terraform` or `tflint` are missing.
+
+When using third-party Terraform pre-commit hook collections that rely on shell scripts, document the supported Windows
+shell environment explicitly, including any Git Bash or WSL assumptions.
+
+<!-- RATIONALE: cross-platform-terraform-pre-commit-hooks -->
+
 ### Workflow
 
 1. Make Terraform changes
@@ -3995,6 +4015,9 @@ Pre-commit hooks for Terraform **SHOULD** include:
 **CI is a safety net, not a substitute for local checks.**
 
 ### Pre-commit Configuration
+
+This example uses `antonbabenko/pre-commit-terraform` and is suitable when a POSIX-compatible shell environment is
+supported for local validation.
 
 ```yaml
 # .pre-commit-config.yaml (Terraform section)

--- a/STYLE_GUIDE_CHAT.md
+++ b/STYLE_GUIDE_CHAT.md
@@ -5,13 +5,13 @@
 
 # Terraform Writing Style
 
-**Version:** 2.3.20260509.0
+**Version:** 2.4.20260511.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-05-09
+- **Last Updated:** 2026-05-11
 - **Scope:** Terraform coding standards for all `.tf`, `.tfvars`, `.tftest.hcl`, `.tf.json`, `.tftpl`, and `.tfbackend` files in this repository — style, formatting, naming, file organization, variable and output design, resource configuration, module design, state management, cross-stack data sharing, provider management, security, testing, and documentation.
 
 ## Keywords
@@ -79,6 +79,7 @@ This checklist provides a quick reference for both human developers and LLMs (li
 ### Continuous Validation (Quick Reference)
 
 - **[All]** `check` blocks **MAY** be used for continuous validation
+- **[All]** Terraform pre-commit hooks **SHOULD** avoid shell assumptions for native Windows/PowerShell contributors
 
 ### Resource Configuration (Quick Reference)
 
@@ -242,7 +243,7 @@ terraform fmt -check -recursive
 terraform fmt -recursive
 ```
 
-**Pre-commit integration:**
+**Pre-commit integration (for repositories with supported POSIX-compatible shell hook execution):**
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3436,7 +3437,10 @@ Security scanning tools **SHOULD** be integrated into the development workflow.
 
 > **Note:** `tfsec` has been absorbed into Aqua Security's `trivy` and is now in maintenance mode. New projects **SHOULD** use `trivy` for Terraform security scanning. Existing workflows using `tfsec` will continue to work but **SHOULD** plan migration to `trivy`.
 
-#### Pre-commit Integration Example
+#### Pre-commit Integration Example (POSIX-compatible Shell)
+
+This example assumes the repository supports POSIX-compatible shell hook execution. Use cross-platform repo-local
+wrappers when native Windows / PowerShell contributors must run hooks without Git Bash or WSL assumptions.
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3986,6 +3990,22 @@ Pre-commit hooks for Terraform **SHOULD** include:
 3. `tflint` — Linting
 4. Security scanning (optional but recommended)
 
+### Cross-platform Hook Execution
+
+Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows /
+PowerShell contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
+WSL, macOS, or Linux for local validation.
+
+For cross-platform Terraform pre-commit validation, prefer repo-local hooks or wrappers in a runtime already required by
+the repository's validation stack, such as Python when pre-commit is already in use. Wrappers **SHOULD** invoke Terraform
+and related tools with shell execution disabled, **SHOULD** resolve executables through `PATH`, and **SHOULD** fail with
+clear installation guidance when required tools such as `terraform` or `tflint` are missing.
+
+When using third-party Terraform pre-commit hook collections that rely on shell scripts, document the supported Windows
+shell environment explicitly, including any Git Bash or WSL assumptions.
+
+<!-- RATIONALE: cross-platform-terraform-pre-commit-hooks -->
+
 ### Workflow
 
 1. Make Terraform changes
@@ -3998,6 +4018,9 @@ Pre-commit hooks for Terraform **SHOULD** include:
 **CI is a safety net, not a substitute for local checks.**
 
 ### Pre-commit Configuration
+
+This example uses `antonbabenko/pre-commit-terraform` and is suitable when a POSIX-compatible shell environment is
+supported for local validation.
 
 ```yaml
 # .pre-commit-config.yaml (Terraform section)

--- a/STYLE_GUIDE_CHAT.md
+++ b/STYLE_GUIDE_CHAT.md
@@ -243,7 +243,7 @@ terraform fmt -check -recursive
 terraform fmt -recursive
 ```
 
-**Pre-commit integration (for repositories with supported POSIX-compatible shell hook execution):**
+**Pre-commit integration (for repositories that support POSIX-compatible shell hook execution):**
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3440,7 +3440,7 @@ Security scanning tools **SHOULD** be integrated into the development workflow.
 #### Pre-commit Integration Example (POSIX-compatible Shell)
 
 This example assumes the repository supports POSIX-compatible shell hook execution. Use cross-platform repo-local
-wrappers when native Windows / PowerShell contributors must run hooks without Git Bash or WSL assumptions.
+wrappers when native Windows/PowerShell contributors must run hooks without Git Bash or WSL assumptions.
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3992,8 +3992,8 @@ Pre-commit hooks for Terraform **SHOULD** include:
 
 ### Cross-platform Hook Execution
 
-Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows /
-PowerShell contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
+Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows/PowerShell
+contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
 WSL, macOS, or Linux for local validation.
 
 For cross-platform Terraform pre-commit validation, prefer repo-local hooks or wrappers in a runtime already required by

--- a/STYLE_GUIDE_FULL.md
+++ b/STYLE_GUIDE_FULL.md
@@ -260,7 +260,7 @@ terraform fmt -check -recursive
 terraform fmt -recursive
 ```
 
-**Pre-commit integration (for repositories with supported POSIX-compatible shell hook execution):**
+**Pre-commit integration (for repositories that support POSIX-compatible shell hook execution):**
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3497,7 +3497,7 @@ Security scanning tools **SHOULD** be integrated into the development workflow.
 #### Pre-commit Integration Example (POSIX-compatible Shell)
 
 This example assumes the repository supports POSIX-compatible shell hook execution. Use cross-platform repo-local
-wrappers when native Windows / PowerShell contributors must run hooks without Git Bash or WSL assumptions.
+wrappers when native Windows/PowerShell contributors must run hooks without Git Bash or WSL assumptions.
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -4059,8 +4059,8 @@ Pre-commit hooks for Terraform **SHOULD** include:
 
 ### Cross-platform Hook Execution
 
-Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows /
-PowerShell contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
+Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows/PowerShell
+contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
 WSL, macOS, or Linux for local validation.
 
 For cross-platform Terraform pre-commit validation, prefer repo-local hooks or wrappers in a runtime already required by
@@ -4071,7 +4071,7 @@ clear installation guidance when required tools such as `terraform` or `tflint` 
 When using third-party Terraform pre-commit hook collections that rely on shell scripts, document the supported Windows
 shell environment explicitly, including any Git Bash or WSL assumptions.
 
-Native Windows / PowerShell contributors can run `pre-commit` successfully, but shell-script hook startup depends on
+Native Windows/PowerShell contributors can run `pre-commit` successfully, but shell-script hook startup depends on
 which `bash` executable appears first on `PATH`. On a workstation with WSL, Git Bash, and other Bash shims installed,
 that resolution can vary by terminal, user profile, or PATH ordering.
 
@@ -5835,7 +5835,7 @@ This section tracks significant changes to the Terraform instruction file.
 
 | Version | Date | Changes |
 | --- | --- | --- |
-| 2.4.20260511.0 | 2026-05-11 | Added cross-platform Terraform pre-commit guidance for native Windows / PowerShell contributors, including shell-execution assumptions, repo-local wrapper recommendations, missing-tool error expectations, and rationale for PATH-dependent Bash failures |
+| 2.4.20260511.0 | 2026-05-11 | Added cross-platform Terraform pre-commit guidance for native Windows/PowerShell contributors, including shell-execution assumptions, repo-local wrapper recommendations, missing-tool error expectations, and rationale for PATH-dependent Bash failures |
 | 2.3.20260503.0 | 2026-05-03 | Added rule requiring Terraform Registry documentation URLs in comments to use the `latest` path segment instead of pinned provider or module versions, with corresponding rationale on Dependabot/comment drift, authoritative version sources, and the comment-only scope of the rule |
 | 2.2.20260412.0 | 2026-04-12 | Reduced token footprint of STYLE_GUIDE.md for LLM/agent consumption: removed TOC, metadata, cross-reference links; condensed RFC 2119 keywords; consolidated multi-provider examples to single AWS representative with inline notes; relocated procedural/runbook content, troubleshooting, changelog, glossary, .tf.json/.tftpl sections, and provider-specific examples to STYLE_GUIDE_RATIONALE.md |
 | 2.1.20260412.0 | 2026-04-12 | Added extended rationale content to companion STYLE_GUIDE_RATIONALE.md: terraform_data advantages over null_resource, environment separation comparison table, workspace limitations, directory-based recommendation details, terraform_remote_state caveats, configuration_aliases rationale, and service account impersonation benefits |

--- a/STYLE_GUIDE_FULL.md
+++ b/STYLE_GUIDE_FULL.md
@@ -2,13 +2,13 @@
 
 # Terraform Writing Style
 
-**Version:** 2.3.20260509.0
+**Version:** 2.4.20260511.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-05-09
+- **Last Updated:** 2026-05-11
 - **Scope:** Terraform coding standards for all `.tf`, `.tfvars`, `.tftest.hcl`, `.tf.json`, `.tftpl`, and `.tfbackend` files in this repository — style, formatting, naming, file organization, variable and output design, resource configuration, module design, state management, cross-stack data sharing, provider management, security, testing, and documentation.
 
 ## Keywords
@@ -76,6 +76,7 @@ This checklist provides a quick reference for both human developers and LLMs (li
 ### Continuous Validation (Quick Reference)
 
 - **[All]** `check` blocks **MAY** be used for continuous validation
+- **[All]** Terraform pre-commit hooks **SHOULD** avoid shell assumptions for native Windows/PowerShell contributors
 
 ### Resource Configuration (Quick Reference)
 
@@ -259,7 +260,7 @@ terraform fmt -check -recursive
 terraform fmt -recursive
 ```
 
-**Pre-commit integration:**
+**Pre-commit integration (for repositories with supported POSIX-compatible shell hook execution):**
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3493,7 +3494,10 @@ Security scanning tools **SHOULD** be integrated into the development workflow.
 
 > **Note:** `tfsec` has been absorbed into Aqua Security's `trivy` and is now in maintenance mode. New projects **SHOULD** use `trivy` for Terraform security scanning. Existing workflows using `tfsec` will continue to work but **SHOULD** plan migration to `trivy`.
 
-#### Pre-commit Integration Example
+#### Pre-commit Integration Example (POSIX-compatible Shell)
+
+This example assumes the repository supports POSIX-compatible shell hook execution. Use cross-platform repo-local
+wrappers when native Windows / PowerShell contributors must run hooks without Git Bash or WSL assumptions.
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -4053,6 +4057,38 @@ Pre-commit hooks for Terraform **SHOULD** include:
 3. `tflint` — Linting
 4. Security scanning (optional but recommended)
 
+### Cross-platform Hook Execution
+
+Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows /
+PowerShell contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
+WSL, macOS, or Linux for local validation.
+
+For cross-platform Terraform pre-commit validation, prefer repo-local hooks or wrappers in a runtime already required by
+the repository's validation stack, such as Python when pre-commit is already in use. Wrappers **SHOULD** invoke Terraform
+and related tools with shell execution disabled, **SHOULD** resolve executables through `PATH`, and **SHOULD** fail with
+clear installation guidance when required tools such as `terraform` or `tflint` are missing.
+
+When using third-party Terraform pre-commit hook collections that rely on shell scripts, document the supported Windows
+shell environment explicitly, including any Git Bash or WSL assumptions.
+
+Native Windows / PowerShell contributors can run `pre-commit` successfully, but shell-script hook startup depends on
+which `bash` executable appears first on `PATH`. On a workstation with WSL, Git Bash, and other Bash shims installed,
+that resolution can vary by terminal, user profile, or PATH ordering.
+
+The observed failure mode was a WSL `bash` process receiving a Windows path to a cached hook script. The path translation
+failed before Terraform started, so the error looked like a missing hook script with stripped backslashes rather than an
+actionable Terraform, TFLint, formatting, linting, or validation failure. Moving Git Bash earlier on `PATH` allowed the
+shell hook to start, but then exposed the separate and expected problem that Terraform itself was not installed.
+
+Repo-local wrappers avoid this ambiguity when native Windows support matters. A wrapper written in a runtime already
+required by the repository's validation stack can locate executables with `shutil.which`, invoke commands with
+`subprocess.run(..., shell=False)`, and report direct installation guidance when `terraform` or `tflint` is missing.
+That keeps failures tied to the actual prerequisite or validation problem instead of to path translation between Windows
+and POSIX-like shells.
+
+This guidance is about hook execution mechanics and actionable error messages. It does not change the guide's Terraform
+toolchain expectations, and it does not require or prohibit OpenTofu support.
+
 ### Workflow
 
 1. Make Terraform changes
@@ -4065,6 +4101,9 @@ Pre-commit hooks for Terraform **SHOULD** include:
 **CI is a safety net, not a substitute for local checks.**
 
 ### Pre-commit Configuration
+
+This example uses `antonbabenko/pre-commit-terraform` and is suitable when a POSIX-compatible shell environment is
+supported for local validation.
 
 ```yaml
 # .pre-commit-config.yaml (Terraform section)
@@ -5796,6 +5835,7 @@ This section tracks significant changes to the Terraform instruction file.
 
 | Version | Date | Changes |
 | --- | --- | --- |
+| 2.4.20260511.0 | 2026-05-11 | Added cross-platform Terraform pre-commit guidance for native Windows / PowerShell contributors, including shell-execution assumptions, repo-local wrapper recommendations, missing-tool error expectations, and rationale for PATH-dependent Bash failures |
 | 2.3.20260503.0 | 2026-05-03 | Added rule requiring Terraform Registry documentation URLs in comments to use the `latest` path segment instead of pinned provider or module versions, with corresponding rationale on Dependabot/comment drift, authoritative version sources, and the comment-only scope of the rule |
 | 2.2.20260412.0 | 2026-04-12 | Reduced token footprint of STYLE_GUIDE.md for LLM/agent consumption: removed TOC, metadata, cross-reference links; condensed RFC 2119 keywords; consolidated multi-provider examples to single AWS representative with inline notes; relocated procedural/runbook content, troubleshooting, changelog, glossary, .tf.json/.tftpl sections, and provider-specific examples to STYLE_GUIDE_RATIONALE.md |
 | 2.1.20260412.0 | 2026-04-12 | Added extended rationale content to companion STYLE_GUIDE_RATIONALE.md: terraform_data advantages over null_resource, environment separation comparison table, workspace limitations, directory-based recommendation details, terraform_remote_state caveats, configuration_aliases rationale, and service account impersonation benefits |

--- a/STYLE_GUIDE_RATIONALE.md
+++ b/STYLE_GUIDE_RATIONALE.md
@@ -10,6 +10,7 @@ This companion document preserves the extended rationale, design philosophy, and
 - [Cross-Stack Data Sharing Rationale](#cross-stack-data-sharing-rationale)
 - [Provider Management Rationale](#provider-management-rationale)
 - [Documentation Rationale](#documentation-rationale)
+- [Pre-commit Rationale](#pre-commit-rationale)
 - [Upgrading Terraform Versions](#upgrading-terraform-versions)
 - [Provider-Specific Examples](#provider-specific-examples)
 - [JSON Configuration Files (.tf.json)](#json-configuration-files-tfjson)
@@ -180,6 +181,32 @@ When a Registry URL in a comment hard-codes a provider or module version (for ex
 Requiring `latest` in the URL path resolves this drift by construction. The `latest` segment on `registry.terraform.io` always redirects to the most recent published documentation for the provider or module, which is the version a reader is most likely interested in when navigating from a comment. Comments stay correct without any maintenance burden.
 
 The rule is intentionally scoped to documentation/navigation comments only. It **does not** alter executable configuration: provider constraints, module `source` addresses, module `version` arguments, `.terraform.lock.hcl`, and selected module `source` references must continue to express the exact, intentional version pinning required for deterministic, reproducible infrastructure. Pinning in those places is a feature; pinning in comments is a maintenance hazard.
+
+---
+
+## Pre-commit Rationale
+
+> For the pre-commit rules themselves, see [Pre-commit Discipline for Terraform](STYLE_GUIDE.md#pre-commit-discipline-for-terraform) in the main guide.
+
+### Cross-platform Terraform Pre-commit Hooks
+
+Native Windows / PowerShell contributors can run `pre-commit` successfully, but shell-script hook startup depends on
+which `bash` executable appears first on `PATH`. On a workstation with WSL, Git Bash, and other Bash shims installed,
+that resolution can vary by terminal, user profile, or PATH ordering.
+
+The observed failure mode was a WSL `bash` process receiving a Windows path to a cached hook script. The path translation
+failed before Terraform started, so the error looked like a missing hook script with stripped backslashes rather than an
+actionable Terraform, TFLint, formatting, linting, or validation failure. Moving Git Bash earlier on `PATH` allowed the
+shell hook to start, but then exposed the separate and expected problem that Terraform itself was not installed.
+
+Repo-local wrappers avoid this ambiguity when native Windows support matters. A wrapper written in a runtime already
+required by the repository's validation stack can locate executables with `shutil.which`, invoke commands with
+`subprocess.run(..., shell=False)`, and report direct installation guidance when `terraform` or `tflint` is missing.
+That keeps failures tied to the actual prerequisite or validation problem instead of to path translation between Windows
+and POSIX-like shells.
+
+This guidance is about hook execution mechanics and actionable error messages. It does not change the guide's Terraform
+toolchain expectations, and it does not require or prohibit OpenTofu support.
 
 ---
 
@@ -1837,6 +1864,7 @@ This section tracks significant changes to the Terraform instruction file.
 
 | Version | Date | Changes |
 | --- | --- | --- |
+| 2.4.20260511.0 | 2026-05-11 | Added cross-platform Terraform pre-commit guidance for native Windows / PowerShell contributors, including shell-execution assumptions, repo-local wrapper recommendations, missing-tool error expectations, and rationale for PATH-dependent Bash failures |
 | 2.3.20260503.0 | 2026-05-03 | Added rule requiring Terraform Registry documentation URLs in comments to use the `latest` path segment instead of pinned provider or module versions, with corresponding rationale on Dependabot/comment drift, authoritative version sources, and the comment-only scope of the rule |
 | 2.2.20260412.0 | 2026-04-12 | Reduced token footprint of STYLE_GUIDE.md for LLM/agent consumption: removed TOC, metadata, cross-reference links; condensed RFC 2119 keywords; consolidated multi-provider examples to single AWS representative with inline notes; relocated procedural/runbook content, troubleshooting, changelog, glossary, .tf.json/.tftpl sections, and provider-specific examples to STYLE_GUIDE_RATIONALE.md |
 | 2.1.20260412.0 | 2026-04-12 | Added extended rationale content to companion STYLE_GUIDE_RATIONALE.md: terraform_data advantages over null_resource, environment separation comparison table, workspace limitations, directory-based recommendation details, terraform_remote_state caveats, configuration_aliases rationale, and service account impersonation benefits |

--- a/STYLE_GUIDE_RATIONALE.md
+++ b/STYLE_GUIDE_RATIONALE.md
@@ -190,7 +190,7 @@ The rule is intentionally scoped to documentation/navigation comments only. It *
 
 ### Cross-platform Terraform Pre-commit Hooks
 
-Native Windows / PowerShell contributors can run `pre-commit` successfully, but shell-script hook startup depends on
+Native Windows/PowerShell contributors can run `pre-commit` successfully, but shell-script hook startup depends on
 which `bash` executable appears first on `PATH`. On a workstation with WSL, Git Bash, and other Bash shims installed,
 that resolution can vary by terminal, user profile, or PATH ordering.
 
@@ -1864,7 +1864,7 @@ This section tracks significant changes to the Terraform instruction file.
 
 | Version | Date | Changes |
 | --- | --- | --- |
-| 2.4.20260511.0 | 2026-05-11 | Added cross-platform Terraform pre-commit guidance for native Windows / PowerShell contributors, including shell-execution assumptions, repo-local wrapper recommendations, missing-tool error expectations, and rationale for PATH-dependent Bash failures |
+| 2.4.20260511.0 | 2026-05-11 | Added cross-platform Terraform pre-commit guidance for native Windows/PowerShell contributors, including shell-execution assumptions, repo-local wrapper recommendations, missing-tool error expectations, and rationale for PATH-dependent Bash failures |
 | 2.3.20260503.0 | 2026-05-03 | Added rule requiring Terraform Registry documentation URLs in comments to use the `latest` path segment instead of pinned provider or module versions, with corresponding rationale on Dependabot/comment drift, authoritative version sources, and the comment-only scope of the rule |
 | 2.2.20260412.0 | 2026-04-12 | Reduced token footprint of STYLE_GUIDE.md for LLM/agent consumption: removed TOC, metadata, cross-reference links; condensed RFC 2119 keywords; consolidated multi-provider examples to single AWS representative with inline notes; relocated procedural/runbook content, troubleshooting, changelog, glossary, .tf.json/.tftpl sections, and provider-specific examples to STYLE_GUIDE_RATIONALE.md |
 | 2.1.20260412.0 | 2026-04-12 | Added extended rationale content to companion STYLE_GUIDE_RATIONALE.md: terraform_data advantages over null_resource, environment separation comparison table, workspace limitations, directory-based recommendation details, terraform_remote_state caveats, configuration_aliases rationale, and service account impersonation benefits |

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -240,7 +240,7 @@ terraform fmt -check -recursive
 terraform fmt -recursive
 ```
 
-**Pre-commit integration (for repositories with supported POSIX-compatible shell hook execution):**
+**Pre-commit integration (for repositories that support POSIX-compatible shell hook execution):**
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3437,7 +3437,7 @@ Security scanning tools **SHOULD** be integrated into the development workflow.
 #### Pre-commit Integration Example (POSIX-compatible Shell)
 
 This example assumes the repository supports POSIX-compatible shell hook execution. Use cross-platform repo-local
-wrappers when native Windows / PowerShell contributors must run hooks without Git Bash or WSL assumptions.
+wrappers when native Windows/PowerShell contributors must run hooks without Git Bash or WSL assumptions.
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3989,8 +3989,8 @@ Pre-commit hooks for Terraform **SHOULD** include:
 
 ### Cross-platform Hook Execution
 
-Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows /
-PowerShell contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
+Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows/PowerShell
+contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
 WSL, macOS, or Linux for local validation.
 
 For cross-platform Terraform pre-commit validation, prefer repo-local hooks or wrappers in a runtime already required by

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -2,13 +2,13 @@
 
 # Terraform Writing Style
 
-**Version:** 2.3.20260509.0
+**Version:** 2.4.20260511.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-05-09
+- **Last Updated:** 2026-05-11
 - **Scope:** Terraform coding standards for all `.tf`, `.tfvars`, `.tftest.hcl`, `.tf.json`, `.tftpl`, and `.tfbackend` files in this repository — style, formatting, naming, file organization, variable and output design, resource configuration, module design, state management, cross-stack data sharing, provider management, security, testing, and documentation.
 
 ## Keywords
@@ -76,6 +76,7 @@ This checklist provides a quick reference for both human developers and LLMs (li
 ### Continuous Validation (Quick Reference)
 
 - **[All]** `check` blocks **MAY** be used for continuous validation
+- **[All]** Terraform pre-commit hooks **SHOULD** avoid shell assumptions for native Windows/PowerShell contributors
 
 ### Resource Configuration (Quick Reference)
 
@@ -239,7 +240,7 @@ terraform fmt -check -recursive
 terraform fmt -recursive
 ```
 
-**Pre-commit integration:**
+**Pre-commit integration (for repositories with supported POSIX-compatible shell hook execution):**
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3433,7 +3434,10 @@ Security scanning tools **SHOULD** be integrated into the development workflow.
 
 > **Note:** `tfsec` has been absorbed into Aqua Security's `trivy` and is now in maintenance mode. New projects **SHOULD** use `trivy` for Terraform security scanning. Existing workflows using `tfsec` will continue to work but **SHOULD** plan migration to `trivy`.
 
-#### Pre-commit Integration Example
+#### Pre-commit Integration Example (POSIX-compatible Shell)
+
+This example assumes the repository supports POSIX-compatible shell hook execution. Use cross-platform repo-local
+wrappers when native Windows / PowerShell contributors must run hooks without Git Bash or WSL assumptions.
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3983,6 +3987,22 @@ Pre-commit hooks for Terraform **SHOULD** include:
 3. `tflint` — Linting
 4. Security scanning (optional but recommended)
 
+### Cross-platform Hook Execution
+
+Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows /
+PowerShell contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
+WSL, macOS, or Linux for local validation.
+
+For cross-platform Terraform pre-commit validation, prefer repo-local hooks or wrappers in a runtime already required by
+the repository's validation stack, such as Python when pre-commit is already in use. Wrappers **SHOULD** invoke Terraform
+and related tools with shell execution disabled, **SHOULD** resolve executables through `PATH`, and **SHOULD** fail with
+clear installation guidance when required tools such as `terraform` or `tflint` are missing.
+
+When using third-party Terraform pre-commit hook collections that rely on shell scripts, document the supported Windows
+shell environment explicitly, including any Git Bash or WSL assumptions.
+
+<!-- RATIONALE: cross-platform-terraform-pre-commit-hooks -->
+
 ### Workflow
 
 1. Make Terraform changes
@@ -3995,6 +4015,9 @@ Pre-commit hooks for Terraform **SHOULD** include:
 **CI is a safety net, not a substitute for local checks.**
 
 ### Pre-commit Configuration
+
+This example uses `antonbabenko/pre-commit-terraform` and is suitable when a POSIX-compatible shell environment is
+supported for local validation.
 
 ```yaml
 # .pre-commit-config.yaml (Terraform section)

--- a/terraform.instructions.md
+++ b/terraform.instructions.md
@@ -245,7 +245,7 @@ terraform fmt -check -recursive
 terraform fmt -recursive
 ```
 
-**Pre-commit integration (for repositories with supported POSIX-compatible shell hook execution):**
+**Pre-commit integration (for repositories that support POSIX-compatible shell hook execution):**
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3442,7 +3442,7 @@ Security scanning tools **SHOULD** be integrated into the development workflow.
 #### Pre-commit Integration Example (POSIX-compatible Shell)
 
 This example assumes the repository supports POSIX-compatible shell hook execution. Use cross-platform repo-local
-wrappers when native Windows / PowerShell contributors must run hooks without Git Bash or WSL assumptions.
+wrappers when native Windows/PowerShell contributors must run hooks without Git Bash or WSL assumptions.
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3994,8 +3994,8 @@ Pre-commit hooks for Terraform **SHOULD** include:
 
 ### Cross-platform Hook Execution
 
-Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows /
-PowerShell contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
+Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows/PowerShell
+contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
 WSL, macOS, or Linux for local validation.
 
 For cross-platform Terraform pre-commit validation, prefer repo-local hooks or wrappers in a runtime already required by

--- a/terraform.instructions.md
+++ b/terraform.instructions.md
@@ -7,13 +7,13 @@ description: "Terraform coding standards: secure, modular, and well-documented i
 
 # Terraform Writing Style
 
-**Version:** 2.3.20260509.0
+**Version:** 2.4.20260511.0
 
 ## Metadata
 
 - **Status:** Active
 - **Owner:** Repository Maintainers
-- **Last Updated:** 2026-05-09
+- **Last Updated:** 2026-05-11
 - **Scope:** Terraform coding standards for all `.tf`, `.tfvars`, `.tftest.hcl`, `.tf.json`, `.tftpl`, and `.tfbackend` files in this repository — style, formatting, naming, file organization, variable and output design, resource configuration, module design, state management, cross-stack data sharing, provider management, security, testing, and documentation.
 
 ## Keywords
@@ -81,6 +81,7 @@ This checklist provides a quick reference for both human developers and LLMs (li
 ### Continuous Validation (Quick Reference)
 
 - **[All]** `check` blocks **MAY** be used for continuous validation
+- **[All]** Terraform pre-commit hooks **SHOULD** avoid shell assumptions for native Windows/PowerShell contributors
 
 ### Resource Configuration (Quick Reference)
 
@@ -244,7 +245,7 @@ terraform fmt -check -recursive
 terraform fmt -recursive
 ```
 
-**Pre-commit integration:**
+**Pre-commit integration (for repositories with supported POSIX-compatible shell hook execution):**
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3438,7 +3439,10 @@ Security scanning tools **SHOULD** be integrated into the development workflow.
 
 > **Note:** `tfsec` has been absorbed into Aqua Security's `trivy` and is now in maintenance mode. New projects **SHOULD** use `trivy` for Terraform security scanning. Existing workflows using `tfsec` will continue to work but **SHOULD** plan migration to `trivy`.
 
-#### Pre-commit Integration Example
+#### Pre-commit Integration Example (POSIX-compatible Shell)
+
+This example assumes the repository supports POSIX-compatible shell hook execution. Use cross-platform repo-local
+wrappers when native Windows / PowerShell contributors must run hooks without Git Bash or WSL assumptions.
 
 ```yaml
 - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -3988,6 +3992,22 @@ Pre-commit hooks for Terraform **SHOULD** include:
 3. `tflint` — Linting
 4. Security scanning (optional but recommended)
 
+### Cross-platform Hook Execution
+
+Terraform pre-commit configuration **SHOULD** be cross-platform when the repository supports native Windows /
+PowerShell contributors. Do not assume POSIX shell hook execution unless the repository explicitly requires Git Bash,
+WSL, macOS, or Linux for local validation.
+
+For cross-platform Terraform pre-commit validation, prefer repo-local hooks or wrappers in a runtime already required by
+the repository's validation stack, such as Python when pre-commit is already in use. Wrappers **SHOULD** invoke Terraform
+and related tools with shell execution disabled, **SHOULD** resolve executables through `PATH`, and **SHOULD** fail with
+clear installation guidance when required tools such as `terraform` or `tflint` are missing.
+
+When using third-party Terraform pre-commit hook collections that rely on shell scripts, document the supported Windows
+shell environment explicitly, including any Git Bash or WSL assumptions.
+
+<!-- RATIONALE: cross-platform-terraform-pre-commit-hooks -->
+
 ### Workflow
 
 1. Make Terraform changes
@@ -4000,6 +4020,9 @@ Pre-commit hooks for Terraform **SHOULD** include:
 **CI is a safety net, not a substitute for local checks.**
 
 ### Pre-commit Configuration
+
+This example uses `antonbabenko/pre-commit-terraform` and is suitable when a POSIX-compatible shell environment is
+supported for local validation.
 
 ```yaml
 # .pre-commit-config.yaml (Terraform section)


### PR DESCRIPTION
## Summary

- Add normative Terraform pre-commit guidance for repositories that support native Windows / PowerShell contributors.
- Label shell-script-based Terraform pre-commit examples as POSIX-compatible shell dependent.
- Add rationale for PATH-dependent Bash failures and missing-tool ambiguity on Windows.
- Regenerate `copilot-instructions.md`, `terraform.instructions.md`, `STYLE_GUIDE_CHAT.md`, and `STYLE_GUIDE_FULL.md` from the canonical sources.
- Normalize generated `terraform.instructions.md` frontmatter output so Windows regeneration keeps LF newlines.

Closes #12.

## Validation

- `./.github/workflows/Generate-StyleGuideArtifacts.ps1`
- `npm run lint:md`
- `npm run lint:md:nested`
- `git diff --check`
