### PR TITLE
Align markdownlint pre-commit hook

### DIFF
--- a/.github/workflows/package.json
+++ b/.github/workflows/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint:md": "cd ../.. && markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.github/workflows/node_modules\" --config .github/workflows/.markdownlint.jsonc",
     "lint:md:nested": "node lint-nested-markdown.js",
-    "prepare": "husky install || true"
+    "prepare": "cd ../.. && husky || true"
   },
   "repository": {
     "type": "git",

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -33,7 +33,6 @@ fi
 
 case "$status" in
   0)
-    exit 0
     ;;
   1)
     echo ""
@@ -54,6 +53,36 @@ case "$status" in
     echo "Exit status: $status"
     echo "Review the output above, then run:"
     echo "npm --prefix .github/workflows run lint:md"
+    exit 1
+    ;;
+esac
+
+echo "Running nested Markdown lint (code fences) with the repository configuration..."
+
+# Mirror the outer lint so the hook checks the same things CI does. Keep the
+# command in an if test to preserve its non-zero status for classification.
+if npm --prefix .github/workflows run lint:md:nested; then
+  nested_status=0
+else
+  nested_status=$?
+fi
+
+case "$nested_status" in
+  0)
+    exit 0
+    ;;
+  1)
+    echo ""
+    echo "Nested Markdown lint reported errors. To see them all, run:"
+    echo "npm --prefix .github/workflows run lint:md:nested"
+    exit 1
+    ;;
+  *)
+    echo ""
+    echo "Nested Markdown lint could not complete because npm or the hook failed unexpectedly."
+    echo "Exit status: $nested_status"
+    echo "Review the output above, then run:"
+    echo "npm --prefix .github/workflows run lint:md:nested"
     exit 1
     ;;
 esac

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,21 +1,59 @@
 #!/bin/sh
 
-# Get list of staged markdown files
-STAGED_MD_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.md$' || true)
-
-if [ -n "$STAGED_MD_FILES" ]; then
-  echo "Running markdownlint on staged files..."
-  npx markdownlint-cli2 $STAGED_MD_FILES
-  LINT_EXIT_CODE=$?
-  
-  if [ $LINT_EXIT_CODE -ne 0 ]; then
-    echo ""
-    echo "❌ Markdownlint failed. Please fix the errors above before committing."
-    echo "To see all errors: npm run lint:md"
-    exit 1
-  fi
-  
-  echo "✅ Markdownlint passed for staged files."
+# Skip unless an added/copied/modified/renamed Markdown path is staged (any directory).
+if git diff --cached --quiet --diff-filter=ACMR -- '*.md'; then
+  exit 0
 fi
 
-exit 0
+if ! command -v npm >/dev/null 2>&1; then
+  echo "Markdown is staged, but npm is not available to this Git hook."
+  echo "Make Node/npm available to the hook environment, then retry."
+  echo "If you use a Node version manager with a GUI Git client, add its initialization"
+  echo "to ~/.config/husky/init.sh, which Husky sources before each hook."
+  echo "(or commit with --no-verify to deliberately skip this check once)"
+  exit 1
+fi
+
+if [ ! -e .github/workflows/node_modules/.bin/markdownlint-cli2 ]; then
+  echo "Markdown is staged, but the Markdown lint tooling is not installed."
+  echo "Run: npm --prefix .github/workflows ci"
+  echo "(or commit with --no-verify to deliberately skip this check once)"
+  exit 1
+fi
+
+echo "Running markdownlint with the repository configuration..."
+
+# Husky runs this file through sh -e, so keep the lint command in an if test
+# to preserve non-zero markdownlint statuses for classification below.
+if npm --prefix .github/workflows run lint:md; then
+  status=0
+else
+  status=$?
+fi
+
+case "$status" in
+  0)
+    exit 0
+    ;;
+  1)
+    echo ""
+    echo "Markdownlint reported errors. To see them all, run:"
+    echo "npm --prefix .github/workflows run lint:md"
+    exit 1
+    ;;
+  2)
+    echo ""
+    echo "markdownlint could not run (a tooling or configuration problem)."
+    echo "Review the output above, then run:"
+    echo "npm --prefix .github/workflows run lint:md"
+    exit 1
+    ;;
+  *)
+    echo ""
+    echo "Markdown lint could not complete because npm or the hook failed unexpectedly."
+    echo "Exit status: $status"
+    echo "Review the output above, then run:"
+    echo "npm --prefix .github/workflows run lint:md"
+    exit 1
+    ;;
+esac

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -73,7 +73,9 @@ case "$nested_status" in
     ;;
   1)
     echo ""
-    echo "Nested Markdown lint reported errors. To see them all, run:"
+    echo "Nested Markdown lint did not pass: it reported errors or could not complete"
+    echo "(a lint, tooling, or configuration problem)."
+    echo "Review the output above, then run:"
     echo "npm --prefix .github/workflows run lint:md:nested"
     exit 1
     ;;


### PR DESCRIPTION
## Summary

- initialize Husky from the repository root using the current `husky` command
- make the pre-commit hook trigger from staged Markdown via Git pathspec/exit-code behavior
- run the repository top-level Markdown lint command so the hook uses the same configuration as CI
- run the nested Markdown lint (`lint:md:nested`) in the outer-success path so the hook checks the same things CI does, with its own actionable exit-code classification
- add actionable hook messages for missing npm, missing tooling, lint errors, tooling/configuration failures, and unexpected npm/hook failures

## Validation

- `npm --prefix .github/workflows ci`
- `npm --prefix .github/workflows run lint:md`
- `npm --prefix .github/workflows run lint:md:nested`
- probe commits for MD013 allowed by repo config and MD040 blocking behavior
- staged Markdown trigger probes for added, modified, copied/duplicated, renamed, and subdirectory files
- nested-lint probe: staged file with a nested `MD001` violation passes the outer lint then fails the nested lint with the correct remediation hint
- missing-`npm`, markdownlint exit `2`, and unexpected npm status classification checks
- `git diff --check`